### PR TITLE
feat: add ability to specify word count

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,15 @@
-const bip39 = require('bip39')
+const bip39 = require('bip39');
+
+import {
+  DEFAULT_COUNT,
+  parseCount,
+  convertCountToStrength,
+} from './util.js';
 
 export function cli(args) {
-  const m = bip39.generateMnemonic();
+  const countStr = args && args[2];
+  const count = countStr ? parseCount(countStr) : DEFAULT_COUNT;
+  const strength = convertCountToStrength(count);
+  const m = bip39.generateMnemonic(strength);
   console.log(m);
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,36 @@
+const DEFAULT_COUNT = 12;
+
+function parseCount(
+  countStr,
+  silent = false,
+  defaultCount = DEFAULT_COUNT,
+) {
+  let count;
+  count = parseInt(countStr);
+  if (isNaN(count)) {
+    if (!silent) {
+      console.error(
+        'failed to parse count input:', countStr);
+    }
+  } else if (count < 12 ||
+      count > 24 ||
+      count % 3 !== 0) {
+    count = undefined;
+    if (!silent) {
+      console.error(
+        'invalid count input, may only be 12, 15, 18, 21, or 24:', countStr);
+    }
+  }
+  return count || defaultCount;
+}
+
+function convertCountToStrength(count) {
+  return count * 32 / 3;
+}
+
+export {
+  DEFAULT_COUNT,
+  parseCount,
+  convertCountToStrength,
+};
+


### PR DESCRIPTION
## What

- Current usage:
  - `mnemonics`
- New usage:
  - `mnemonics 15`
  - (plus, current usage retained)
- Input validation added

## Why

- Add ability for users to specify the number of words they would like in their mnemonic, instead of always using the default value

## Note
  - The new functionality was put into `src/utils.js`, in anticipation of making it easier to write tests.
  - Given that there are currently no tests, I figured that adding them, and adding a test runner, would be something for a separate PR.
